### PR TITLE
fix'd spellings in code and updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Homebridge Philips Andorid TV
+# Homebridge Philips Android TV
 
 This plug-in provides support for Homebridge Philips Android TVs.
 
@@ -30,7 +30,7 @@ Scf-Fi:
 
 Android TV 2016 models Philips use an authenticated HTTPS JointSpace API version 6.
 Every control- or status-call needs digest authentification which contains of a pre generated username and password.
-You have to do this once for your TV, to use the python script philips_android_tv.
+You have to do this once for your TV, to use the python script [philips_android_tv](https://github.com/suborb/philips_android_tv).
 
 Here is an example pairing call for philips_android_tv :
 
@@ -60,8 +60,15 @@ You can then add username and password key in your homebridge config
             "TVN 7",
             "TV6"
         ],
-        "alternativePlayPause": true # Sends Play or Pause alternating, based on internal state, instead of PlayPause to TV when not defined (false)
+        "alternativePlayPause": true
     }
+
+
+| Option                 | Description                                                                                                   | Default |  Example  |
+|------------------------|---------------------------------------------------------------------------------------------------------------|---------|-----------|
+| alternativePlayPause   | Sends Play or Pause alternating, based on internal state, instead of PlayPause to TV when not defined (false) | false   | true      |
+
+[comment]: <> (Maybe adding more options in table?)
 
 Accessory is registered as "External Accessory", it has to be once added manually in Home app as option without code scan and enter code from Homebridge logs.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This plug-in provides support for Homebridge Philips Android TVs.
 
 ## Info
 
-Plug-in tested on 49PUS7101 ( API 6.2.0 ) & 75PUS7354 ( API 6.4.0 )
+Plug-in tested on 50PUS7303 ( API 6.1.0 ), 49PUS7101 ( API 6.2.0 ), 75PUS7354 & 65OLED804/12 ( API 6.4.0 )
 
 Working:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -511,7 +511,7 @@ class PhilipsAndroidTvAccessory implements AccessoryPlugin {
                             callback(null, true);
                             return;
                         }
-                        this.log.debug('Device ' + this.config.name + ' is standby. ' + body);
+                        this.log.debug('Device ' + this.config.name + ' is in standby mode. ' + body);
                         callback(null, false);
                     } else {
                         this.log.debug('Device ' + this.config.name + ' is offline. ' + response.statusCode);
@@ -615,18 +615,18 @@ class PhilipsAndroidTvAccessory implements AccessoryPlugin {
 
     wakeOnLan(callback) {
         if (!this.config.macAddress) {
-            this.log.debug('MAC Address not confgiured, no wakey');
+            this.log.debug('MAC address not configured, no wakey');
             if (callback) {
                 callback();
             }
             return;
         }
-        this.log.debug('Trying to wake ' + this.config.name + ' on ' + this.config.macAddress);
+        this.log.debug('Try to wake up ' + this.config.name + ' on ' + this.config.macAddress);
         wol.wake(this.config.macAddress, { address: '255.255.255.255' }, function (this, error) {
             if (error) {
                 this.log.warn('Error when sending WOL packets', error);
             } else {
-                this.log.debug('Wake Pakcets sends succesfful');
+                this.log.debug('WOL packets sends successful');
                 if (callback) {
                     callback();
                 }


### PR DESCRIPTION
I fix'd some spellings in `index.ts` which were directed to the debug log. Also updated the `README.md` - adding supported devices and APIs and removes the commentary `#` inside the config-example (commentary [is not allowed](https://stackoverflow.com/a/244858) in `JSON`).