### PR TITLE
Send state updates to HomeKit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "displayName": "Philips Android TV",
     "name": "homebridge-philips-android-tv",
-    "version": "0.10.9",
+    "version": "0.10.10",
     "description": "Plugin for Philips Android TV",
     "license": "Apache-2.0",
     "repository": {

--- a/src/PhilipsTVAccessory.ts
+++ b/src/PhilipsTVAccessory.ts
@@ -213,13 +213,13 @@ export class PhilipsTVAccessory {
                 if (!this.on) {
                     this.log.info('[' + this.config.name + '] TV has been turn on.');
                     this.on = true;
-                    this.tvService.updateCharacteristic(this.api.hap.Characteristic.Active, this.on);
+                    this.tvService!.updateCharacteristic(this.api.hap.Characteristic.Active, this.on);
                 }
             } else {
                 if (this.on) {
                     this.log.info('[' + this.config.name + '] TV has been turned off.');
                     this.on = false;
-                    this.tvService.updateCharacteristic(this.api.hap.Characteristic.Active, this.on);
+                    this.tvService!.updateCharacteristic(this.api.hap.Characteristic.Active, this.on);
                 }
             }
             
@@ -231,8 +231,8 @@ export class PhilipsTVAccessory {
                 if (volume > 0) {
                     this.lastPositiveVolume = this.volume;
                 }
-                this.tvSpeaker.updateCharacteristic(this.api.hap.Characteristic.Volume, this.volume);
-                this.tvSpeaker.updateCharacteristic(this.api.hap.Characteristic.Mute, this.volume === 0);
+                this.tvSpeaker!.updateCharacteristic(this.api.hap.Characteristic.Volume, this.volume);
+                this.tvSpeaker!.updateCharacteristic(this.api.hap.Characteristic.Mute, this.volume === 0);
             }
 
             const app = await this.tv.getCurrentActivity();

--- a/src/PhilipsTVAccessory.ts
+++ b/src/PhilipsTVAccessory.ts
@@ -213,11 +213,13 @@ export class PhilipsTVAccessory {
                 if (!this.on) {
                     this.log.info('[' + this.config.name + '] TV has been turn on.');
                     this.on = true;
+                    this.tvService.updateCharacteristic(this.api.hap.Characteristic.Active, this.on);
                 }
             } else {
                 if (this.on) {
                     this.log.info('[' + this.config.name + '] TV has been turned off.');
                     this.on = false;
+                    this.tvService.updateCharacteristic(this.api.hap.Characteristic.Active, this.on);
                 }
             }
             
@@ -229,6 +231,8 @@ export class PhilipsTVAccessory {
                 if (volume > 0) {
                     this.lastPositiveVolume = this.volume;
                 }
+                this.tvSpeaker.updateCharacteristic(this.api.hap.Characteristic.Volume, this.volume);
+                this.tvSpeaker.updateCharacteristic(this.api.hap.Characteristic.Mute, this.volume === 0);
             }
 
             const app = await this.tv.getCurrentActivity();


### PR DESCRIPTION
Closes #45

Changes checkStatus function to send updates to HomeKit:
 - tvService Active
 - tvSpeaker Mute
 - tvSpeaker Volume

Maybe this should also be added for the current application and channel.

I tested this on my local instance (with only tvService active) and it worked like expected.
I don't have any experience with the Homebridge API so I don't know if this is the right way to do it, however, it was used like this in the [Homebridge Plugin Template](https://github.com/homebridge/homebridge-plugin-template/blob/7f32bc3f1c8af56a92f47bc9e850e4d999b32f0e/src/platformAccessory.ts#L86).